### PR TITLE
CardEditView max Lenght

### DIFF
--- a/KambanSolution/Kamban/Views/CardEditView.xaml
+++ b/KambanSolution/Kamban/Views/CardEditView.xaml
@@ -25,8 +25,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="34" />
             <RowDefinition Height="Auto" MinHeight="20"/>
-            <RowDefinition Height="Auto" MinHeight="20"/>
-            <RowDefinition Height="Auto" MinHeight="200"/>
+            <RowDefinition  Height="Auto" MinHeight="20"/>
+            <RowDefinition  Height="Auto" MinHeight="200" MaxHeight="400" x:Name="row3"/>
             <RowDefinition Height="Auto" MinHeight="40"/>
         </Grid.RowDefinitions>
 
@@ -113,6 +113,10 @@
             BorderThickness="0">Description</Label>
 
         <wpfresources:SelectionBindingTextBox 
+            x:Name="BodyTextBox"
+            VerticalAlignment="Stretch"
+            MaxHeight="{Binding ElementName=row3, Path=MaxHeight}"
+            VerticalScrollBarVisibility="Visible"
             BorderThickness="0"
             FontSize="16"
             TabIndex="2"


### PR DESCRIPTION
If you copy&paste to much text in the body of CardEditView the buttons at the end of the card are out of the screen.  Fast Fix using a maxLenght.

Maybe there are more elegant solutions?

Question for my better understanding:
*) What ist the main reason to implement this view as a flyout and not as a normal window (wich would allow easy resizing/moving)? 
Is it:
- to have this desing with thick border and unmovable position?
- or does it simplify something in the code?
- or any other reason?
